### PR TITLE
Switch to using Maven's provided instead of reflection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,11 @@
 	<properties>
 		<maven.version>2.2.1</maven.version>
 		<scala.version>2.11</scala.version>
-		<scala.lib.version>2.11.5</scala.lib.version>
+		<scala.lib.version>2.11.7</scala.lib.version>
 		<scala-io.version>0.4.3-1</scala-io.version>
+		<specs2.version>2.4.17</specs2.version>
+		<java.source.version>1.5</java.source.version>
+		<java.target.version>1.5</java.target.version>
 	</properties>
 
 	<build>
@@ -50,6 +53,7 @@
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>
 				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.2.2</version>
 				<configuration>
 					<recompileMode>all</recompileMode>	<!-- NOTE: "incremental" compilation although faster may require passing to MAVEN_OPTS="-XX:MaxPermSize=128m" -->
 					<useZincServer>true</useZincServer>	<!-- NOTE: if you have Zinc server installed and running compilation will be offloaded which can speed things up -->
@@ -73,21 +77,11 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<configuration>
-					<includes>
-						<include>**/*</include>
-					</includes>
-				</configuration>
-			</plugin>
-			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.2</version>
 				<configuration>
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>${java.source.version}</source>
+					<target>${java.target.version}</target>
 				</configuration>
 				<executions>
 					<execution>
@@ -100,8 +94,37 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<includes>
+						<include>**/*</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals>
+							<goal>analyze-only</goal>
+						</goals>
+						<configuration>
+							<failOnWarning>true</failOnWarning>
+							<ignoredUnusedDeclaredDependencies>
+								<ignoredUsedUndeclaredDependency>org.specs2:specs2-junit_${scala.version}:jar:${specs2.version}</ignoredUsedUndeclaredDependency>
+							</ignoredUnusedDeclaredDependencies>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.4</version>
+				<version>1.5</version>
 				<executions>
 					<execution>
 						<id>sign-artifacts</id>
@@ -123,7 +146,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-artifact</artifactId>
+			<artifactId>maven-model</artifactId>
 			<version>${maven.version}</version>
 		</dependency>
 		<dependency>
@@ -138,20 +161,29 @@
 		</dependency>
 		<dependency>
 			<groupId>com.github.scala-incubator.io</groupId>
-			<artifactId>scala-io-core_${scala.version}</artifactId>
-			<version>${scala-io.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.scala-incubator.io</groupId>
 			<artifactId>scala-io-file_${scala.version}</artifactId>
 			<version>${scala-io.version}</version>
 		</dependency>
-		<!-- for specs2 to generate HTML reports -->
+
 		<dependency>
-			<groupId>org.pegdown</groupId>
-			<artifactId>pegdown</artifactId>
-			<version>1.4.2</version>
+			<groupId>org.specs2</groupId>
+			<artifactId>specs2-core_${scala.version}</artifactId>
+			<version>${specs2.version}</version>
+			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.specs2</groupId>
+			<artifactId>specs2-html_${scala.version}</artifactId>
+			<version>${specs2.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.specs2</groupId>
+			<artifactId>specs2-junit_${scala.version}</artifactId>
+			<version>${specs2.version}</version>
+			<scope>provided</scope>
+		</dependency><!-- not actually needed until runtime -->
+
 		<!-- specifies interface of objects that need to be passed to specs2 TestFrameworkRunner -->
 		<dependency>
 			<groupId>org.scala-tools.testing</groupId>
@@ -159,10 +191,11 @@
 			<version>0.5</version>
 		</dependency>
 		<!-- for specs2 to generate JUnit XML -->
-		<dependency>
+		<!-- dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
-		</dependency>
+			<scope>runtime</scope>
+		</dependency -->
 	</dependencies>
 </project>

--- a/src/main/scala/com/mmakowski/maven/plugins/specs2/Specs2Runner.scala
+++ b/src/main/scala/com/mmakowski/maven/plugins/specs2/Specs2Runner.scala
@@ -121,21 +121,16 @@ class Specs2Runner(args: String) {
   // runners with signatures expected by this plug-in.
     
   private class TestInterfaceRunner(classLoader: ClassLoader, log: Log) {
-    val RunnerClassName = "org.specs2.runner.TestInterfaceRunner"
-    val runnerClass = classLoader.loadClass(RunnerClassName)
-    val runner = runnerClass.getConstructor(classOf[ClassLoader], classOf[Array[Logger]]).newInstance(classLoader, Array(new MavenLogLogger(log)))
-    val runSpecificationMethod = runnerClass.getMethod("runSpecification", classOf[String], classOf[EventHandler], classOf[Array[String]]) 
-    
+    import org.specs2.runner.{TestInterfaceRunner => Specs2TestInterfaceRunner}
+    val runner = new Specs2TestInterfaceRunner(classLoader, Array(new MavenLogLogger(log)))
     def runSpecification(spec: String, handler: EventHandler, modes: Array[String]) = 
-      runSpecificationMethod.invoke(runner, spec, handler, modes)
+      runner.runSpecification(spec, handler, modes)
   }
   
   private class HtmlRunner(classLoader: ClassLoader) {
-    val RunnerClassName = "org.specs2.runner.HtmlRunner"
-    val runnerClass = classLoader.loadClass(RunnerClassName)
-    val runner = runnerClass.getConstructor().newInstance()
-    val startMethod = runnerClass.getMethod("start", classOf[Seq[String]])
+    import org.specs2.runner.{HtmlRunner => Specs2HtmlRunner}
+    val runner = new Specs2HtmlRunner()
     
-    def start(spec: String) = startMethod.invoke(runner, Seq(spec))
+    def start(spec: String) = runner.start(Seq(spec):_*)
   }
 }

--- a/test/java-custom-suffix/pom.xml
+++ b/test/java-custom-suffix/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.mmakowski</groupId>
     <artifactId>specs2-maven-plugin-tests</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>    
 
   <artifactId>specs2-maven-plugin-test-java-custom-suffix</artifactId>
@@ -16,12 +16,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.mmakowski</groupId>
         <artifactId>specs2-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-html_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <suffix>CustomSuff</suffix>
         </configuration>
@@ -31,22 +48,28 @@
  
   <dependencies>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.specs2</groupId>
-      <artifactId>specs2_${scala.version}</artifactId>
-      <version>${specs2.version}</version>
+      <artifactId>specs2-core_${scala.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.specs2</groupId>
+      <artifactId>specs2-junit_${scala.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
        <groupId>junit</groupId>
        <artifactId>junit</artifactId>
-       <version>4.9</version>
        <scope>test</scope>
     </dependency>
     <!-- for specs2 to generate HTML reports -->
     <dependency>
       <groupId>org.pegdown</groupId>
       <artifactId>pegdown</artifactId>
-      <version>1.0.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test/java-simple/pom.xml
+++ b/test/java-simple/pom.xml
@@ -16,12 +16,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.mmakowski</groupId>
         <artifactId>specs2-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-html_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>
@@ -33,28 +50,40 @@
       <version>2.6</version>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.lib.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.specs2</groupId>
-      <artifactId>specs2_${scala.version}</artifactId>
-      <version>${specs2.version}</version>
+      <artifactId>specs2-core_${scala.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.specs2</groupId>
+      <artifactId>specs2-junit_${scala.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.specs2</groupId>
+      <artifactId>specs2-mock_${scala.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- for specs2 to generate HTML reports -->
     <dependency>
       <groupId>org.pegdown</groupId>
       <artifactId>pegdown</artifactId>
-      <version>1.0.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test/java-spring/main/pom.xml
+++ b/test/java-spring/main/pom.xml
@@ -16,12 +16,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.mmakowski</groupId>
         <artifactId>specs2-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-core_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-html_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.specs2</groupId>
+            <artifactId>specs2-junit_${scala.version}</artifactId>
+            <version>${specs2.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>
@@ -38,15 +55,24 @@
       <version>3.0.6.RELEASE</version>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.lib.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.specs2</groupId>
-      <artifactId>specs2_${scala.version}</artifactId>
-      <version>${specs2.version}</version>
+      <artifactId>specs2-core_${scala.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.specs2</groupId>
+      <artifactId>specs2-junit_${scala.version}</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- for specs2 to generate HTML reports -->

--- a/test/java-spring/pom.xml
+++ b/test/java-spring/pom.xml
@@ -7,7 +7,7 @@
 	</parent>    
 
 	<artifactId>specs2-maven-plugin-test-java-spring</artifactId>
-  <packaging>pom</packaging>
+  	<packaging>pom</packaging>
 
 	<name>java-spring</name>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -15,26 +15,24 @@
 	
 	<properties>
 		<scala.version>2.11</scala.version>
-		<specs2.version>2.3.11</specs2.version>
+		<scala.lib.version>2.11.7</scala.lib.version>
+		<specs2.version>2.4.17</specs2.version>
         <plugin.version>0.4.5-SNAPSHOT</plugin.version>
+		<java.source.version>1.6</java.source.version>
+		<java.target.version>1.6</java.target.version>
 	</properties>
 
 	<build>
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
+					<groupId>net.alchim31.maven</groupId>
+					<artifactId>scala-maven-plugin</artifactId>
+					<version>3.2.2</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<recompileMode>all</recompileMode>	<!-- NOTE: "incremental" compilation although faster may require passing to MAVEN_OPTS="-XX:MaxPermSize=128m" -->
+						<useZincServer>true</useZincServer>	<!-- NOTE: if you have Zinc server installed and running compilation will be offloaded which can speed things up -->
 					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.scala-tools</groupId>
-					<artifactId>maven-scala-plugin</artifactId>
-					<version>2.15.2</version>
 					<executions>
 						<execution>
 							<id>scala-compile-first</id>
@@ -54,6 +52,15 @@
 					</executions>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.2</version>
+					<configuration>
+						<source>${java.source.version}</source>
+						<target>${java.target.version}</target>
+					</configuration>
+				</plugin>
+				<plugin>
 					<groupId>com.mmakowski</groupId>
 					<artifactId>specs2-maven-plugin</artifactId>
 					<version>${plugin.version}</version>
@@ -70,6 +77,52 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.scala-lang</groupId>
+				<artifactId>scala-library</artifactId>
+				<version>${scala.lib.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.12</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-all</artifactId>
+				<version>1.8.5</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.specs2</groupId>
+				<artifactId>specs2-core_${scala.version}</artifactId>
+				<version>${specs2.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.specs2</groupId>
+				<artifactId>specs2-mock_${scala.version}</artifactId>
+				<version>${specs2.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.specs2</groupId>
+				<artifactId>specs2-junit_${scala.version}</artifactId>
+				<version>${specs2.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.pegdown</groupId>
+				<artifactId>pegdown</artifactId>
+				<version>1.0.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<modules>
         <module>java-spring</module>


### PR DESCRIPTION
I believe that this should allow the same amount of Specs2 version independence for users of the plugin, but for developers of the plugin it allows static compilation of dependencies to ensure the API hasn't changed.

I see this as the first step in updating the specs2-maven-plugin to support the 3.x series of Specs2 which has a different API.